### PR TITLE
Implement item retrieval

### DIFF
--- a/features/agile_keychain/retrieve.feature
+++ b/features/agile_keychain/retrieve.feature
@@ -1,0 +1,16 @@
+Feature: Retrieving items from the keychain
+  So that I can retrieve my secrets
+  As an API user
+  I must be able to get items from the keychain
+
+  Scenario: Retrieving an item from the keychain
+    Given I have an initialised keychain
+    And an item with ID "123" has been added to the keychain
+    When I get an item by ID "123"
+    Then I should get the added item
+
+  Scenario: Retrieving all items from the keychain
+    Given I have an initialised keychain
+    And a number of items is added to the keychain
+    When I iterate the items in the keychain
+    Then I should encounter all the added items

--- a/features/agile_keychain/retrieve_item.feature
+++ b/features/agile_keychain/retrieve_item.feature
@@ -1,1 +1,0 @@
-Feature: Retrieve item from the keychain

--- a/features/agile_keychain/retrieve_list_of_items.feature
+++ b/features/agile_keychain/retrieve_list_of_items.feature
@@ -1,1 +1,0 @@
-Feature: Retrieve the list of items from a keychain

--- a/features/steps/agile_keychain_retrieve_steps.py
+++ b/features/steps/agile_keychain_retrieve_steps.py
@@ -1,0 +1,52 @@
+import os
+from openpassword.exceptions import MissingIdAttributeException
+
+TEMP_KEYCHAIN_PATH = os.path.join('tests', 'fixtures', 'temp.agilekeychain')
+
+
+@given('an item with ID "{item_id}" has been added to the keychain')
+def step_impl(context, item_id):
+    _add_item(context, {'id': item_id})
+
+
+@given('a number of items is added to the keychain')
+def step_impl(context):
+    _add_item(context, {'id': '123'})
+    _add_item(context, {'id': '456'})
+    _add_item(context, {'id': '789'})
+
+
+@when('I get an item by ID "{item_id}"')
+def step_impl(context, item_id):
+    if hasattr(context, 'retrieved_items') is False:
+        context.retrieved_items = []
+
+    context.retrieved_items.append(context.keychain[item_id])
+
+
+@then('I should get the added item')
+def step_impl(context):
+    assert context.retrieved_items[0] == context.added_items[0]
+
+
+@when('I iterate the items in the keychain')
+def step_impl(context):
+    if hasattr(context, 'retrieved_items') is False:
+        context.retrieved_items = []
+
+    for item in context.keychain:
+        context.retrieved_items.append(item)
+
+
+@then('I should encounter all the added items')
+def step_impl(context):
+    for item in context.retrieved_items:
+        assert item in context.added_items
+
+
+def _add_item(context, item):
+    if hasattr(context, 'added_items') is False:
+        context.added_items = []
+
+    context.added_items.append(item)
+    context.keychain.append(item)

--- a/features/steps/agile_keychain_write_steps.py
+++ b/features/steps/agile_keychain_write_steps.py
@@ -2,8 +2,6 @@ import os
 from openpassword.exceptions import MissingIdAttributeException
 
 TEMP_KEYCHAIN_PATH = os.path.join('tests', 'fixtures', 'temp.agilekeychain')
-CORRECT_PASSWORD = "correctpassword"
-INCORRECT_PASSWORD = "incorrectpassword"
 
 
 @when('I append a new password to the keychain')

--- a/openpassword/_keychain.py
+++ b/openpassword/_keychain.py
@@ -54,4 +54,16 @@ class Keychain(object):
         return item in self._items.values()
 
     def __iter__(self):
-        return iter(self._items)
+        return ItemIterator(self._items)
+
+
+class ItemIterator(object):
+    def __init__(self, items):
+        self._items = items
+        self._iterator = iter(self._items)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self._items[self._iterator.__next__()]

--- a/openpassword/_keychain.py
+++ b/openpassword/_keychain.py
@@ -54,16 +54,4 @@ class Keychain(object):
         return item in self._items.values()
 
     def __iter__(self):
-        return ItemIterator(self._items)
-
-
-class ItemIterator(object):
-    def __init__(self, items):
-        self._items = items
-        self._iterator = iter(self._items)
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return self._items[self._iterator.__next__()]
+        return iter(self._items.values())

--- a/spec/openpassword/keychain_spec.py
+++ b/spec/openpassword/keychain_spec.py
@@ -98,6 +98,20 @@ class KeychainSpec:
         keychain.append(new_item)
         eq_(new_item in keychain, True)
 
+    def it_iterates_over_items(self):
+        keychain = self._get_simple_keychain()
+        items = [
+            {'id': '123'},
+            {'id': '456'},
+            {'id': '789'}
+        ]
+
+        for item in items:
+            keychain.append(item)
+
+        for item in keychain:
+            assert item in items
+
     @raises(MissingIdAttributeException)
     def it_throws_an_missingidattributeexception_when_id_attribute_is_missing_from_item(self):
         keychain = self._get_simple_keychain()


### PR DESCRIPTION
Implement's item retrieval both:
 - as dictionary, by getting an item by it's id
 - as a list, by iterating over the keychain

The 1% coverage drop seems to come from ItemIterator.__iter__, which according to the docs is required to conform the the iterator protocol, but doesn't end up being called here.