### PR TITLE
Feature/initialisation configuration

### DIFF
--- a/features/steps/agile_keychain_change_keychain_password_steps.py
+++ b/features/steps/agile_keychain_change_keychain_password_steps.py
@@ -10,7 +10,7 @@ TEMP_KEYCHAIN_PATH = os.path.join('tests', 'fixtures', 'temp.agilekeychain')
 @given('I have a keychain initialised with "{password}"')
 def step_impl(context, password):
     context.keychain = openpassword.AgileKeychain(TEMP_KEYCHAIN_PATH)
-    context.keychain.initialise(password)
+    context.keychain.initialise(password, {'iterations': 10})
     context.remove_path = TEMP_KEYCHAIN_PATH
 
 

--- a/features/steps/agile_keychain_initialise_steps.py
+++ b/features/steps/agile_keychain_initialise_steps.py
@@ -16,7 +16,7 @@ def step_impl(context):
 @given('I have an initialised keychain')
 def step_impl(context):
     context.keychain = openpassword.AgileKeychain(TEMP_KEYCHAIN_PATH)
-    context.keychain.initialise(CORRECT_PASSWORD)
+    context.keychain.initialise(CORRECT_PASSWORD, {'iterations': 10})
     context.remove_path = TEMP_KEYCHAIN_PATH
 
 
@@ -31,7 +31,7 @@ def step_impl(context):
 
 @when('I initialise it using "{password}"')
 def step_impl(context, password):
-    context.keychain.initialise(password)
+    context.keychain.initialise(password, {'iterations': 10})
     context.remove_path = TEMP_KEYCHAIN_PATH
 
 
@@ -44,7 +44,7 @@ def step_impl(context):
 def step_impl(context):
     context.initialisation_failed = False
     try:
-        context.keychain.initialise("somepassword")
+        context.keychain.initialise("somepassword", {'iterations': 10})
     except KeychainAlreadyInitialisedException:
         context.initialisation_failed = True
 

--- a/features/steps/agile_keychain_locking_steps.py
+++ b/features/steps/agile_keychain_locking_steps.py
@@ -63,5 +63,5 @@ def step_impl(context):
 
 def _add_new_keychain_to_context(context):
     context.keychain = openpassword.AgileKeychain(TEMP_KEYCHAIN_PATH)
-    context.keychain.initialise(CORRECT_PASSWORD)
+    context.keychain.initialise(CORRECT_PASSWORD, {'iterations': 10})
     context.remove_path = TEMP_KEYCHAIN_PATH

--- a/openpassword/_keychain.py
+++ b/openpassword/_keychain.py
@@ -23,11 +23,11 @@ class Keychain(object):
     def is_locked(self):
         return self.locked
 
-    def initialise(self, password, configuration=None):
+    def initialise(self, password, config=None):
         if self.initialised is True:
             raise KeychainAlreadyInitialisedException
 
-        self._data_source.initialise(password, configuration)
+        self._data_source.initialise(password, config)
         self.initialised = True
 
     def is_initialised(self):

--- a/openpassword/_keychain.py
+++ b/openpassword/_keychain.py
@@ -23,11 +23,11 @@ class Keychain(object):
     def is_locked(self):
         return self.locked
 
-    def initialise(self, password):
+    def initialise(self, password, configuration=None):
         if self.initialised is True:
             raise KeychainAlreadyInitialisedException
 
-        self._data_source.initialise(password)
+        self._data_source.initialise(password, configuration)
         self.initialised = True
 
     def is_initialised(self):

--- a/openpassword/abstract/data_source.py
+++ b/openpassword/abstract/data_source.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 class DataSource(metaclass=ABCMeta):
 
     @abstractmethod
-    def initialise(self, path):
+    def initialise(self, path, config=None):
         return NotImplemented
 
     @abstractmethod

--- a/openpassword/agile_keychain/data_source.py
+++ b/openpassword/agile_keychain/data_source.py
@@ -26,7 +26,7 @@ class DataSource(abstract.DataSource):
         buildnum_file.write(self.BUILD_NUMBER)
         buildnum_file.close()
 
-    def initialise(self, password, config={}):
+    def initialise(self, password, config=None):
         os.makedirs(self._default_folder)
         os.makedirs(self._config_folder)
 
@@ -35,7 +35,7 @@ class DataSource(abstract.DataSource):
         for agile_keychain_base_file in AGILE_KEYCHAIN_BASE_FILES:
             open(os.path.join(self._default_folder, agile_keychain_base_file), "w+").close()
 
-        self._initialise_key_files(password, self._get_iterations(config))
+        self._initialise_key_files(password, self._read_iterations_from_config(config))
 
         self.set_password(password)
 
@@ -63,7 +63,10 @@ class DataSource(abstract.DataSource):
             key.encrypt_with_password(password)
             self._key_manager.save_key(key)
 
-    def _get_iterations(self, config):
+    def _read_iterations_from_config(self, config):
+        if type(config) is not dict:
+            return DEFAULT_ITERATIONS
+
         if 'iterations' in config:
             return config['iterations']
 

--- a/openpassword/agile_keychain/data_source.py
+++ b/openpassword/agile_keychain/data_source.py
@@ -26,7 +26,7 @@ class DataSource(abstract.DataSource):
         buildnum_file.write(self.BUILD_NUMBER)
         buildnum_file.close()
 
-    def initialise(self, password):
+    def initialise(self, password, configuration={}):
         os.makedirs(self._default_folder)
         os.makedirs(self._config_folder)
 
@@ -35,7 +35,10 @@ class DataSource(abstract.DataSource):
         for agile_keychain_base_file in AGILE_KEYCHAIN_BASE_FILES:
             open(os.path.join(self._default_folder, agile_keychain_base_file), "w+").close()
 
-        self._initialise_key_files(password)
+        if 'iterations' in configuration:
+            self._initialise_key_files(password, configuration['iterations'])
+        else:
+            self._initialise_key_files(password)
 
         self.set_password(password)
 

--- a/openpassword/agile_keychain/data_source.py
+++ b/openpassword/agile_keychain/data_source.py
@@ -26,7 +26,7 @@ class DataSource(abstract.DataSource):
         buildnum_file.write(self.BUILD_NUMBER)
         buildnum_file.close()
 
-    def initialise(self, password, configuration={}):
+    def initialise(self, password, config={}):
         os.makedirs(self._default_folder)
         os.makedirs(self._config_folder)
 
@@ -35,10 +35,7 @@ class DataSource(abstract.DataSource):
         for agile_keychain_base_file in AGILE_KEYCHAIN_BASE_FILES:
             open(os.path.join(self._default_folder, agile_keychain_base_file), "w+").close()
 
-        if 'iterations' in configuration:
-            self._initialise_key_files(password, configuration['iterations'])
-        else:
-            self._initialise_key_files(password)
+        self._initialise_key_files(password, self._get_iterations(config))
 
         self.set_password(password)
 
@@ -66,6 +63,12 @@ class DataSource(abstract.DataSource):
             key.encrypt_with_password(password)
             self._key_manager.save_key(key)
 
+    def _get_iterations(self, config):
+        if 'iterations' in config:
+            return config['iterations']
+
+        return DEFAULT_ITERATIONS
+
     def _validate_agile_keychain_base_files(self):
         is_initialised = True
         for base_file in AGILE_KEYCHAIN_BASE_FILES:
@@ -79,7 +82,7 @@ class DataSource(abstract.DataSource):
     def _is_valid_folder(self, folder):
         return os.path.exists(folder) and os.path.isdir(folder)
 
-    def _initialise_key_files(self, password, iterations=DEFAULT_ITERATIONS):
+    def _initialise_key_files(self, password, iterations):
         level3_key = self._key_manager.create_key(password, security_level='SL3', iterations=iterations)
         level5_key = self._key_manager.create_key(password, security_level='SL5', iterations=iterations)
 

--- a/spec/openpassword/agile_keychain/key_spec.py
+++ b/spec/openpassword/agile_keychain/key_spec.py
@@ -21,11 +21,11 @@ class KeySpec:
         key.decrypt_with_password('new_and_better_password')
 
     def it_creates_key(self):
-        key = Key.create('password', 'SL4', 1000)
+        key = Key.create('password', 'SL4', 10)
         key.decrypt_with_password('password')
 
         assert key.security_level == 'SL4'
-        assert key.iterations == 1000
+        assert key.iterations == 10
 
     def get_key(self):
         return Key({

--- a/spec/openpassword/keychain_spec.py
+++ b/spec/openpassword/keychain_spec.py
@@ -52,6 +52,15 @@ class KeychainSpec:
         keychain.initialise("somepassword")
         eq_(keychain.is_initialised(), True)
 
+    @patch('openpassword.agile_keychain.data_source')
+    def it_passes_initialisation_configuraton_to_data_source(self, data_source):
+        password = "somepassword"
+        config = {"iterations": 10}
+        keychain = Keychain(data_source)
+        keychain.initialise(password, config)
+
+        data_source.initialise.assert_called_with(password, config)
+
     def it_keeps_uninitialised_if_we_dont_initialise_it(self):
         keychain = self._get_non_initialised_keychain()
         eq_(keychain.is_initialised(), False)

--- a/tests/integration/openpassword/agile_keychain/test_data_source.py
+++ b/tests/integration/openpassword/agile_keychain/test_data_source.py
@@ -47,6 +47,17 @@ class AgileKeychainDataSourceTest:
         os.remove(os.path.join('tests', 'fixtures', 'test.agilekeychain', 'data', 'default',
                                '79cd94b00ab34d209d62e487e77965a5.1password'))
 
+    def it_reads_iteration_count_from_initialisation_configuration(self):
+        iterations = 123
+
+        data_source = DataSource(self._temporary_path)
+        data_source.initialise(self._password, {'iterations': iterations})
+
+        for key in data_source._key_manager.get_keys():
+            assert key.iterations == iterations
+
+        self.teardown = self._path_clean
+
     def _initialise_data_source(self):
         self._data_source = DataSource(self._temporary_path)
         self._data_source.initialise(self._password)

--- a/tests/integration/openpassword/agile_keychain/test_data_source.py
+++ b/tests/integration/openpassword/agile_keychain/test_data_source.py
@@ -60,7 +60,7 @@ class AgileKeychainDataSourceTest:
 
     def _initialise_data_source(self):
         self._data_source = DataSource(self._temporary_path)
-        self._data_source.initialise(self._password)
+        self._data_source.initialise(self._password, {'iterations': 10})
         self.teardown = self._path_clean
 
     def _path_clean(self):


### PR DESCRIPTION
Allow passing initialisation configuration to the keychain, and read iteration count from said configuration if present.

This is not only a useful feature in itself, but allows us to speed up tests as well by not deriving keys with unnecessarily high iteration counts when not relevant for the test.